### PR TITLE
Fix not guild-only commands

### DIFF
--- a/src/Invoker/index.ts
+++ b/src/Invoker/index.ts
@@ -203,7 +203,7 @@ export default class Invoker implements InvokerContract {
    * Throws if command is guild only but context isn't
    */
   private guildMatches() {
-    if (this.Command.$guildOnly !== this.$context.isGuild()) {
+    if (this.Command.$guildOnly && !this.$context.isGuild()) {
       throw new ForbiddenCommandException(
         'GUILD_ONLY_COMMAND',
         this.Command.code,

--- a/src/Parser/index.ts
+++ b/src/Parser/index.ts
@@ -3,7 +3,6 @@ import CommandContext from '../CommandContext'
 import ParserContract from './ParserContract'
 import BadInputException from '../Exceptions/BadInputException'
 import StaticCommandContract from '../BaseCommand/StaticCommandContract'
-
 export default class Parser implements ParserContract {
   /**
    * The name of the input
@@ -70,7 +69,7 @@ export default class Parser implements ParserContract {
             this.$command.name,
             name,
             `Argument '${name}' (${i +
-              1}º) expects a numeric value, ${input} given`
+              1}º) expects a numeric value, '${input}' given`
           )
         }
 
@@ -128,6 +127,21 @@ export default class Parser implements ParserContract {
                 .users.cache.get(mention)
 
               context.set(name, user)
+            } else {
+              /**
+               * If the mention is not valid, then we must warn the user.
+               *
+               * Mention arguments can only be validated at execution
+               * time, otherwise we would have to check twice if the
+               * user is present in the users cache.
+               */
+              throw new BadInputException(
+                'ARGUMENT_IS_NOT_A_MENSION',
+                this.$command.code,
+                name,
+                `Argument '${name}' (${i +
+                  1}º) expected a mention as value, received: '${argValue}'`
+              )
             }
           } else {
             /**

--- a/test/input-validation.spec.ts
+++ b/test/input-validation.spec.ts
@@ -45,7 +45,7 @@ describe('Input validation', () => {
 
     expect(() =>
       new Parser('numeric nan').forCommand(NumericArgument).isValid()
-    ).toThrow("Argument 'first' (1º) expects a numeric value, nan given")
+    ).toThrow("Argument 'first' (1º) expects a numeric value, 'nan' given")
   })
 
   it('should return false when code does not  match', () => {

--- a/test/pre-checks.spec.ts
+++ b/test/pre-checks.spec.ts
@@ -73,6 +73,13 @@ class GuildOnlyCommand extends BaseCommand {
   public execute() {}
 }
 
+@Command({
+  code: 'not-guild-only',
+})
+class NotGuildOnlyCommand extends BaseCommand {
+  public execute() {}
+}
+
 describe('Roles and permisssions', () => {
   describe('Roles', () => {
     it('should allow if user have the role', () => {
@@ -278,6 +285,22 @@ describe('Roles and permisssions', () => {
   })
 
   describe('Guild-only', () => {
+    it('should allow to execute not guild-only command from outside a guild', () => {
+      const FakeContext = {
+        getMember() {
+          return {}
+        },
+
+        isGuild() {
+          return false
+        },
+      } as CommandContextContract
+
+      return expect(
+        new Invoker(NotGuildOnlyCommand).withContext(FakeContext).invoke()
+      ).resolves.not.toThrow()
+    })
+
     it('should not allow to execute guild-only command from outside a guild', () => {
       const FakeContext = {
         getMember() {


### PR DESCRIPTION
This PR fixes some bugs and improve error reports:

- Allow to execute not guild-only command from outside a guild (bug)
- Reports the error to the user if a mention argument doesn'tt receive a mention