### PR TITLE
Fix: development mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,18 +8,15 @@
     "src"
   ],
   "engines": {
-    "node": ">=10"
+    "node": ">=14"
   },
   "scripts": {
     "start": "tsdx watch",
     "build": "tsdx build",
     "test": "tsdx test",
     "lint": "tsdx lint",
-    "prepare": "tsdx build",
-    "size": "size-limit",
-    "analyze": "size-limit --why"
+    "prepare": "tsdx build"
   },
-  "peerDependencies": {},
   "husky": {
     "hooks": {
       "pre-commit": "tsdx lint"
@@ -32,12 +29,13 @@
     "trailingComma": "es5"
   },
   "name": "discapp",
-  "author": "Jota",
+  "author": "Jota Júnior <jjunior@protonmail.ch>",
   "module": "dist/discapp.esm.js",
+  "peerDependencies": {
+    "discord.js": "^12.5.1"
+  },
   "devDependencies": {
-    "@size-limit/preset-small-lib": "^4.9.1",
     "husky": "^4.3.8",
-    "size-limit": "^4.9.1",
     "ts-node": "^9.1.1",
     "tsdx": "^0.14.1",
     "tslib": "^2.1.0",

--- a/src/Application/index.ts
+++ b/src/Application/index.ts
@@ -10,6 +10,7 @@ import pick from '../utils/pick'
 import BadInputException from '../Exceptions/BadInputException'
 import ForbiddenCommandException from '../Exceptions/ForbiddenCommandException'
 import ApplicationContract from './ApplicationContract'
+import { isString } from '../utils/isType'
 import { DiscappConfig, MessageContract } from '../types'
 
 export default class Application implements ApplicationContract {
@@ -44,6 +45,13 @@ export default class Application implements ApplicationContract {
   }
 
   /**
+   * Returns the Application config
+   */
+  public getConfig() {
+    return this.$config
+  }
+
+  /**
    * Start the app with the preferred configs
    *
    * @param config The configuration
@@ -71,10 +79,12 @@ export default class Application implements ApplicationContract {
         this.respond(message, response)
       }
     } else {
-      if (typeof responses === 'string') {
-        message.reply(responses)
+      const response = responses
+
+      if (isString(response)) {
+        message.reply(response)
       } else {
-        message.reply({ embed: responses })
+        message.reply({ embed: response })
       }
     }
   }

--- a/src/Parser/index.ts
+++ b/src/Parser/index.ts
@@ -3,6 +3,7 @@ import CommandContext from '../CommandContext'
 import ParserContract from './ParserContract'
 import BadInputException from '../Exceptions/BadInputException'
 import StaticCommandContract from '../BaseCommand/StaticCommandContract'
+
 export default class Parser implements ParserContract {
   /**
    * The name of the input

--- a/src/Storage.ts
+++ b/src/Storage.ts
@@ -14,13 +14,6 @@ export default class Storage {
   private static $app: ApplicationContract | undefined
 
   /**
-   * Code-based predicate
-   */
-  private static byCodePredicate = (code: string) => {
-    return (Command: StaticCommandContract) => Command.code === code
-  }
-
-  /**
    * If true then the Storage will work in development
    * mode
    */
@@ -50,7 +43,9 @@ export default class Storage {
    * Get the command by code
    */
   public static getCommand(code: string): StaticCommandContract | undefined {
-    return this.$commands.find(this.byCodePredicate(code))
+    return this.$commands.find(
+      (Command: StaticCommandContract) => Command.code === code
+    )
   }
 
   /**
@@ -69,9 +64,9 @@ export default class Storage {
    */
   public static removeCommand(Command: StaticCommandContract | string) {
     if (isString(Command)) {
-      this.$commands = this.$commands.filter(
-        () => !this.byCodePredicate(Command)
-      )
+      this.$commands = this.$commands.filter(CommandToFilter => {
+        return CommandToFilter.code != Command
+      })
     } else {
       const index = this.$commands.indexOf(Command)
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,10 +27,10 @@ export interface ArgumentDecoratorOptions {
 export interface MessageContract extends Message {}
 
 export interface DiscappConfig {
-  commandsDirectory: string
-  token: string
+  readonly commandsDirectory: string
+  readonly token: string
   hooks: DiscappHooks
-  prefix: string
+  readonly prefix: string
 }
 
 export interface InvokerHooks {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6985,9 +6985,9 @@ pretty-format@^25.2.1, pretty-format@^25.5.0:
     react-is "^16.12.0"
 
 prism-media@^1.2.2:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/prism-media/-/prism-media-1.2.3.tgz#37bbb11726674a73fe56a2df4de76aa91d2141b7"
-  integrity sha512-fSrR66n0l6roW9Rx4rSLMyTPTjRTiXy5RVqDOurACQ6si1rKHHKDU5gwBJoCsIV0R3o9gi+K50akl/qyw1C74A==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/prism-media/-/prism-media-1.2.6.tgz#9e86f69c14342f546c96b7c1461cc8b3e46b48a3"
+  integrity sha512-I1Ys8HA+9aSKQ2jbkO3r6p9Z+tMpSssGhucgxXvc0sSpOi0kK550rDQnKtAS7Z5TzPQeLJdBmK2Br8x+5137lg==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -9073,10 +9073,15 @@ ws@^6.0.0:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^7.0.0, ws@^7.3.1:
+ws@^7.0.0:
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.2.tgz#782100048e54eb36fe9843363ab1c68672b261dd"
   integrity sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==
+
+ws@^7.3.1:
+  version "7.4.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.3.tgz#1f9643de34a543b8edb124bdcbc457ae55a6e5cd"
+  integrity sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This methods fixes the development mode, improves typing and introduces a way of retrieving the Discapp config from the Application.

## Fix hot reloading

A error was causing that - when in dev mode - the Storage would remove all commands when a command was changed. This error should be fixeed.

Still there are some things to improve in command hot reloading that I'm already aware but still thinking in the best solution for solving, e.g: when renaming the code of a command to a new code, the old command will not be deleted.


## Retrieving the Application config

Added `Appllication.getConfig` method that returns the Application config, also improved the type of `DiscappConfig`, assigning all the configs, excepct for hooks to readonly.